### PR TITLE
New settings flag UpgradePublisedApps

### DIFF
--- a/template/build-settings-template.json
+++ b/template/build-settings-template.json
@@ -81,7 +81,8 @@
             "DeployToTenants": [
                 "<blank for all tenants>"
             ],
-            "InstallNewApps": false
+            "InstallNewApps": false,
+            "UpgradePublishedApps": true
         },
         {
             "branch": "<disabled>",


### PR DESCRIPTION
New flag in build-settings-template.json called **UpgradePublishedApps**. Only affects DeploymentType **host** (both global and PTE scope) if set to true or if the flag is omitted the app will be upgraded to the new version if already installed. If the flag is set to false the upgrade will not happen, this has to be done manually.